### PR TITLE
1.0.0-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.0.0-0]
 ### Changed
 - ***Breaking change:*** xd2svg accepts only string input type, it may be directory or file, see [example](example/convert-directory.js)
 - Improved code coverage
 - Improved typing
 - Refactored all tests
 - Updated examples, README
+- Terminal output
+- Updated jsdom to 12.0.0
 
 ### Fixed
 - Fixed crash when params doesn't present in filters
 - Fixed issue when filters doesn't proceed if they have not 'visible' property
+
+### Removed
+- All refs to "format" option
 
 ## [0.8.1]
 ### Added
@@ -260,7 +266,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add Artboard parser
 
-[Unreleased]: https://github.com/L2jLiga/xd2svg/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/L2jLiga/xd2svg/compare/v1.0.0-0...HEAD
+[1.0.0-0]: https://github.com/L2jLiga/xd2svg/compare/v0.8.1...v1.0.0-0
 [0.8.1]: https://github.com/L2jLiga/xd2svg/compare/v0.8.0...v0.8.0
 [0.8.0]: https://github.com/L2jLiga/xd2svg/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/L2jLiga/xd2svg/compare/v0.7.1...v0.7.2

--- a/example/convert-directory.js
+++ b/example/convert-directory.js
@@ -12,7 +12,6 @@ async function prepareSvg(inputFileName) {
   await promisify(extract)(inputFileName, {dir});
 
   const preparedSvgs = xd2svg(dir, {
-    format: 'svg',
     single: false
   });
 

--- a/index.ts
+++ b/index.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://github.com/L2jLiga/xd2svg/LICENSE
  */
 
-export * from './src/xd2svg';
+export * from './lib/xd2svg';

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "extract-zip": "1.6.7",
-    "jsdom": "11.12.0",
+    "jsdom": "12.0.0",
     "svgo": "1.0.5",
     "tmp": "0.0.33"
   },
@@ -61,7 +61,7 @@
     "@types/extract-zip": "1.6.2",
     "@types/jsdom": "11.0.6",
     "@types/mocha": "5.2.5",
-    "@types/node": "8.10.25",
+    "@types/node": "8.10.26",
     "@types/sinon": "5.0.1",
     "@types/svgo": "1.0.1",
     "@types/tmp": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xd2svg",
-  "version": "0.8.1",
+  "version": "1.0.0-0",
   "description": "Utility for converting Adobe XD files (*.xd) to SVG",
   "keywords": [
     "svg",

--- a/package.json
+++ b/package.json
@@ -83,11 +83,10 @@
   "nyc": {
     "all": true,
     "include": [
-      "src/**/*.ts"
+      "src/xd2svg.ts",
+      "src/core/**/*.ts"
     ],
     "exclude": [
-      "**/cli.ts",
-      "**/cli/**",
       "**/*.d.ts",
       "**/*.spec.ts",
       "**/assets/**",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,11 +10,19 @@ import { checkArgv }   from './cli/check-argv';
 import { convertXd }   from './cli/convert-xd';
 import { CliOptions }  from './cli/models';
 import { parseParams } from './cli/parse-params';
+import * as logger     from './utils/logger';
 
 checkArgv();
 
 const options: CliOptions = parseParams();
 
-console.log(`Proceed file %s with options\n%O`, process.argv[2], options);
+console.log(logger.blue(logger.bold('XD2SVG starts their work, given input:')) +
+  logger.blue('filename: ') + '%s\n' +
+  logger.blue('output type: ') + '%s\n' +
+  logger.blue('output path: ') + '%s',
+  process.argv[2],
+  options.single ? 'single' : 'multiple',
+  options.output,
+);
 
 convertXd(process.argv[2], options);

--- a/src/cli/check-argv.ts
+++ b/src/cli/check-argv.ts
@@ -5,22 +5,17 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://github.com/L2jLiga/xd2svg/LICENSE
  */
-
-import { existsSync } from 'fs';
+import * as logger from '../utils/logger';
 
 export function checkArgv(): void {
-  if (!process.argv[2]) {
-    console.log(`Usage: xd2svg-cli InputFile.xd [options]
-  options:
-  -o, --output - specify output path (default FileName directory or FileName.svg)
-  -f, --format - specify output format: svg, jpg, png (default: svg)
-  -s, --single - specify does output should be single file with all artboards or directory with separated each other (default: true)
+  if (process.argv[2]) return;
+
+  console.log(`${logger.bold('Usage:')} xd2svg-cli InputFile.xd [options]
+  ${logger.bold('options:')}
+  ${logger.bold('-o, --output')} - specify output path (default FileName directory or FileName.svg)
+  ${logger.bold('-s, --single')} - specify does output should be single file with all artboards or directory with separated each other (default: true)
 
   For additional information: man xd2svg-cli`);
 
-    process.exit(0);
-  } else if (!existsSync(process.argv[2])) {
-    console.log(`Couldn't find ${process.argv[2]}, are you sure that you write filename right?`);
-    process.exit(-1);
-  }
+  process.exit(0);
 }

--- a/src/cli/convert-xd.ts
+++ b/src/cli/convert-xd.ts
@@ -17,7 +17,7 @@ export async function convertXd(input: string, options: CliOptions): Promise<voi
 
   typeof svgImages === 'string' ?
     writeFile(options.output, svgImages, errorHandler)
-    : Object.keys(svgImages).map((key) => writeFile(`${options.output}/${key}.${options.format}`, svgImages[key], errorHandler));
+    : Object.keys(svgImages).map((key) => writeFile(`${options.output}/${key}.svg`, svgImages[key], errorHandler));
 }
 
 function preparePath(options: CliOptions): void {

--- a/src/cli/convert-xd.ts
+++ b/src/cli/convert-xd.ts
@@ -7,6 +7,7 @@
  */
 
 import { existsSync, mkdirSync, writeFile } from 'fs';
+import * as logger                          from '../utils/logger';
 import xd2svg                               from '../xd2svg';
 import { CliOptions, OutputFormat }         from './models';
 
@@ -38,5 +39,7 @@ function preparePath(options: CliOptions): void {
 }
 
 function errorHandler(error) {
-  if (error) throw error;
+  logger.error('An error occured while flushing to disk, reason: %O', error);
+
+  throw error;
 }

--- a/src/cli/models/cli-options.ts
+++ b/src/cli/models/cli-options.ts
@@ -7,7 +7,6 @@
  */
 
 export interface CliOptions {
-  format?: 'svg';
   output?: string;
   single?: boolean;
 }

--- a/src/cli/parse-params.ts
+++ b/src/cli/parse-params.ts
@@ -19,7 +19,6 @@ export function parseParams(): CliOptions {
   }
 
   const options: CliOptions = {
-    format: 'svg',
     output: inputName.join('.'),
     single: true,
   };
@@ -42,7 +41,7 @@ export function parseParams(): CliOptions {
   }
 
   if (!customOutput && options.single) {
-    options.output += `.${options.format}`;
+    options.output += `.svg`;
   }
 
   return options;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,18 @@
+export function error(message: string, ...args: any[]) {
+  console.error(`\u001b[31m
+${bold('ERROR HAPPENS!')}
+${'='.repeat(75)}
+${message}\u001b[39m`, ...args);
+}
+
+export function bold(s: string) {
+  return `\u001b[1m${s}\u001b[22m`;
+}
+
+export function red(s: string) {
+  return `\u001b[31m${s}\u001b[39m`;
+}
+
+export function blue(s: string) {
+  return `\u001b[34m${s}\u001b[39m`;
+}

--- a/src/xd2svg.ts
+++ b/src/xd2svg.ts
@@ -13,6 +13,7 @@ import { promisify }                   from 'util';
 import { CliOptions, OutputFormat }    from './cli/models';
 import { optimizeSvg, proceedFile }    from './core';
 import { Dictionary, Directory }       from './core/models';
+import * as logger                     from './utils/logger';
 
 const extract = promisify(extractZip);
 
@@ -38,7 +39,9 @@ export default async function xd2svg(input: string, options: CliOptions): Promis
 
 async function openMockup(inputFile): Promise<Directory> {
   if (!existsSync(inputFile)) {
-    throw new Error('File doesn\'t exists!');
+    logger.error(`No such file or directory: ${inputFile}, please make sure that path is correct`);
+
+    throw null;
   }
 
   if (lstatSync(inputFile).isDirectory()) {
@@ -51,7 +54,9 @@ async function openMockup(inputFile): Promise<Directory> {
 
   await extract(inputFile, {dir: directory.name})
     .catch((error) => {
-      throw new Error(error);
+      logger.error(`Unable to unpack XD, please make sure that provided file is correct`);
+
+      throw error;
     });
 
   return directory;

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,9 +123,9 @@
   version "10.5.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.8.tgz#6f14ccecad1d19332f063a6a764f8907801fece0"
 
-"@types/node@8.10.25":
-  version "8.10.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.25.tgz#801fe4e39372cef18f268db880a5fbfcf71adc7e"
+"@types/node@8.10.26":
+  version "8.10.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.26.tgz#950e3d4e6b316ba6e1ae4e84d9155aba67f88c2f"
 
 "@types/sinon@5.0.1":
   version "5.0.1"
@@ -143,10 +143,6 @@
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.3.tgz#7f226d67d654ec9070e755f46daebf014628e9d9"
 
-abab@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
-
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -157,7 +153,7 @@ acorn-globals@^4.1.0:
   dependencies:
     acorn "^5.0.0"
 
-acorn@^5.0.0, acorn@^5.5.3:
+acorn@^5.0.0, acorn@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
@@ -569,13 +565,13 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-urls@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.0.0.tgz#24802de4e81c298ea8a9388bb0d8e461c774684f"
+data-urls@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.0.1.tgz#d416ac3896918f29ca84d81085bc3705834da579"
   dependencies:
-    abab "^1.0.4"
-    whatwg-mimetype "^2.0.0"
-    whatwg-url "^6.4.0"
+    abab "^2.0.0"
+    whatwg-mimetype "^2.1.0"
+    whatwg-url "^7.0.0"
 
 date-format@^0.0.0:
   version "0.0.0"
@@ -711,7 +707,7 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escodegen@^1.9.1:
+escodegen@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
   dependencies:
@@ -955,7 +951,7 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@^0.4.8:
+iconv-lite@0.4.23, iconv-lite@^0.4.8:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
@@ -1134,35 +1130,34 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@11.12.0:
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
+jsdom@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-12.0.0.tgz#043ffaac60605d87adf77a1ec3eb7686918b6b64"
   dependencies:
     abab "^2.0.0"
-    acorn "^5.5.3"
+    acorn "^5.7.1"
     acorn-globals "^4.1.0"
     array-equal "^1.0.0"
     cssom ">= 0.3.2 < 0.4.0"
     cssstyle "^1.0.0"
-    data-urls "^1.0.0"
+    data-urls "^1.0.1"
     domexception "^1.0.1"
-    escodegen "^1.9.1"
+    escodegen "^1.11.0"
     html-encoding-sniffer "^1.0.2"
-    left-pad "^1.3.0"
-    nwsapi "^2.0.7"
-    parse5 "4.0.0"
+    nwsapi "^2.0.8"
+    parse5 "5.1.0"
     pn "^1.1.0"
-    request "^2.87.0"
+    request "^2.88.0"
     request-promise-native "^1.0.5"
     sax "^1.2.4"
     symbol-tree "^3.2.2"
-    tough-cookie "^2.3.4"
+    tough-cookie "^2.4.3"
     w3c-hr-time "^1.0.1"
     webidl-conversions "^4.0.2"
-    whatwg-encoding "^1.0.3"
+    whatwg-encoding "^1.0.4"
     whatwg-mimetype "^2.1.0"
-    whatwg-url "^6.4.1"
-    ws "^5.2.0"
+    whatwg-url "^7.0.0"
+    ws "^6.0.0"
     xml-name-validator "^3.0.0"
 
 jsesc@^2.5.1:
@@ -1213,10 +1208,6 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
-
-left-pad@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
 levn@~0.3.0:
   version "0.3.0"
@@ -1438,7 +1429,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nwsapi@^2.0.7:
+nwsapi@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.8.tgz#e3603579b7e162b3dbedae4fb24e46f771d8fa24"
 
@@ -1592,7 +1583,11 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
-parse5@4.0.0, parse5@^4.0.0:
+parse5@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+
+parse5@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
 
@@ -1791,7 +1786,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.55.0, request@^2.87.0:
+request@^2.55.0, request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   dependencies:
@@ -2093,7 +2088,7 @@ to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
-tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
+tough-cookie@>=2.3.3, tough-cookie@^2.4.3, tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
   dependencies:
@@ -2243,19 +2238,25 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
-whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
+whatwg-encoding@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz#57c235bc8657e914d24e1a397d3c82daee0a6ba3"
   dependencies:
     iconv-lite "0.4.19"
 
-whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
+whatwg-encoding@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz#63fb016b7435b795d9025632c086a5209dbd2621"
+  dependencies:
+    iconv-lite "0.4.23"
+
+whatwg-mimetype@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
 
-whatwg-url@^6.4.0, whatwg-url@^6.4.1:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+whatwg-url@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
@@ -2306,9 +2307,15 @@ write-file-atomic@^2.0.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-ws@^5.1.1, ws@^5.2.0:
+ws@^5.1.1:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.0.0.tgz#eaa494aded00ac4289d455bac8d84c7c651cef35"
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
### Changed
- ***Breaking change:*** xd2svg accepts only string input type, it may be directory or file, see [example](example/convert-directory.js)
- Improved code coverage
- Improved typing
- Refactored all tests
- Updated examples, README
- Terminal output
- Updated jsdom to 12.0.0

### Fixed
- Fixed crash when params doesn't present in filters
- Fixed issue when filters doesn't proceed if they have not 'visible' property

### Removed
- All refs to "format" option