### PR TITLE
Added parameter to use source objects instead of compound path

### DIFF
--- a/man/xd2svg.1
+++ b/man/xd2svg.1
@@ -12,6 +12,9 @@ xd2svg - convert xd file to svg or html
 [
 .BI "\fB-s\fR, \fB\-\-signle\fR=" "true"
 ]
+[
+.BI "\fB-s\fR, \fB\-\-prefer\-compound\-path\fR=" "true"
+]
 .SH DESCRIPTION
 .B xd2svg
 is utility for converting Adobe XD files (*.xd) to SVG or HTML
@@ -25,13 +28,18 @@ The default destination path is specified by the input file name.
 
 .TP
 .BI "\fB-s\fR, \fB\-\-single\fR=" "boolean"
-.R Specify does output should be single file with all artboards or directory with separated each other.
+.R Single file output.
 .R The default value is \fBfalse.
 
 .TP
 .BI "\fB-p\fR, \fB\-\-pretty\-print\fR=" "boolean"
-.R Specify does output should be pretty printed (default: false).
+.R Pretty printed output.
 .R The default value is \fBfalse.
+
+.TP
+.BI "\fB-p\fR, \fB\-\-prefer\-compound\-path\fR=" "boolean"
+.R Use compound path instead of source objects.
+.R The default value is \fBtrue.
 
 .SH BUGS
 List of bugs can be found at https://github.com/L2jLiga/xd2svg/issues

--- a/package.json
+++ b/package.json
@@ -100,6 +100,8 @@
       ".ts"
     ],
     "reporter": [
+      "text",
+      "text-summary",
       "lcovonly"
     ]
   },

--- a/src/cli/check-argv.ts
+++ b/src/cli/check-argv.ts
@@ -12,9 +12,10 @@ export function checkArgv(): void {
 
   console.log(`${logger.bold('Usage:')} xd2svg-cli InputFile.xd [options]
   ${logger.bold('options:')}
-  ${logger.bold('-o, --output')}       - specify output path (default FileName directory or FileName.svg)
-  ${logger.bold('-s, --single')}       - specify does output should be single file with all artboards or directory with separated each other (default: false)
-  ${logger.bold('-p, --pretty-print')} - specify does output should be pretty printed (default: false)
+  ${logger.bold('-o, --output')}           - output path (default FileName directory or FileName.svg)
+  ${logger.bold('-s, --single')}           - single file output (default: false)
+  ${logger.bold('-p, --pretty-print')}     - pretty printed output (default: false)
+  ${logger.bold('--prefer-compound-path')} - use compound path instead of source objects (default: true)
 
   For additional information: man xd2svg-cli`);
 

--- a/src/cli/parse-params.ts
+++ b/src/cli/parse-params.ts
@@ -44,6 +44,10 @@ export function parseParams(): CliOptions {
       case '--single':
         options.single = !/^f/i.test(value);
         break;
+
+      case '--prefer-compound-path':
+        options.preferCompoundPath = !/^f/i.test(value);
+        break;
     }
   }
 

--- a/src/common/options.ts
+++ b/src/common/options.ts
@@ -9,9 +9,19 @@
 export interface Options {
   single?: boolean;
   prettyPrint?: boolean;
+  preferCompoundPath?: boolean;
+}
+
+export interface SingleOutput extends Options {
+  single: true;
+}
+
+export interface MultipleOutput extends Options {
+  single: false;
 }
 
 export const defaultOptions: Options = {
+  preferCompoundPath: true,
   prettyPrint: false,
   single: false,
 };

--- a/src/core/models/artboard.ts
+++ b/src/core/models/artboard.ts
@@ -9,28 +9,31 @@
 import { Shape } from './shape';
 import { Text }  from './text';
 
-interface CommonArtboard {
+export interface ArtboardLike {
+  children: Artboard[];
+}
+
+interface CommonArtboard extends ArtboardLike{
   id?: string;
   name?: string;
   type?: string;
-  children: Artboard[];
   artboard?: Artboard;
   visible?: boolean;
   style: { [style: string]: any };
   transform: { [transform: string]: any };
 }
 
-interface ShapeArtboard extends CommonArtboard {
+export interface ShapeArtboard extends CommonArtboard {
   type: 'shape';
   shape: Shape;
 }
 
-interface TextArtboard extends CommonArtboard {
+export interface TextArtboard extends CommonArtboard {
   type: 'text';
   text: Text;
 }
 
-interface GroupArtboard extends CommonArtboard {
+export interface GroupArtboard extends CommonArtboard {
   type: 'group';
   group: Artboard;
 }

--- a/src/core/models/artboard.ts
+++ b/src/core/models/artboard.ts
@@ -13,7 +13,7 @@ export interface ArtboardLike {
   children: Artboard[];
 }
 
-interface CommonArtboard extends ArtboardLike{
+interface CommonArtboard extends ArtboardLike {
   id?: string;
   name?: string;
   type?: string;

--- a/src/core/models/shape.ts
+++ b/src/core/models/shape.ts
@@ -7,18 +7,18 @@
  */
 import { Artboard } from './artboard';
 
-interface Path {
+export interface Path {
   type: 'path';
   path: string;
 }
 
-interface CompoundPath {
+export interface CompoundPath {
   type: 'compound';
   path: string;
   children: Artboard[];
 }
 
-interface Rectangle {
+export interface Rectangle {
   type: 'rect';
   x: number;
   y: number;
@@ -27,14 +27,14 @@ interface Rectangle {
   height: number;
 }
 
-interface Circle {
+export interface Circle {
   type: 'circle';
   cx: number;
   cy: number;
   r: number;
 }
 
-interface Ellipse {
+export interface Ellipse {
   type: 'ellipse';
   cx: number;
   cy: number;
@@ -42,7 +42,7 @@ interface Ellipse {
   ry: number;
 }
 
-interface Line {
+export interface Line {
   type: 'line';
   x1: number;
   y1: number;

--- a/src/core/resources-parser.ts
+++ b/src/core/resources-parser.ts
@@ -9,10 +9,10 @@
 import { readFileSync }                      from 'fs';
 import * as builder                          from 'xmlbuilder';
 import { Dictionary, Directory }             from '../common';
-import { createElem }                        from './artboard-converter';
 import { ArtboardInfo }                      from './models';
 import { Color }                             from './styles/models';
 import { colorTransformer, defs, gradients } from './utils';
+import { createElem }                        from './utils/create-elem';
 
 export function resourcesParser(directory: Directory): Dictionary<ArtboardInfo> {
   const json = readFileSync(`${directory.name}/resources/graphics/graphicContent.agc`, 'utf-8');

--- a/src/core/utils/create-elem.ts
+++ b/src/core/utils/create-elem.ts
@@ -1,0 +1,100 @@
+import { XMLElementOrXMLNode }                  from 'xmlbuilder';
+import { Options }                              from '../../common';
+import * as logger                              from '../../utils/logger';
+import { createShape, TextConverter }           from '../converters';
+import { createStyles }                         from '../create-styles';
+import { Artboard, Shape }                      from '../models';
+import { ArtboardLike }                         from '../models/artboard';
+import { applyIfPossible }                      from './guarded-ops';
+import { svgRectToClipPath, SvgRectToClipPath } from './svg-rect-to-clip-path';
+
+export function createElem(collection: ArtboardLike, parent: XMLElementOrXMLNode, defs: XMLElementOrXMLNode, options: Options = {}): XMLElementOrXMLNode {
+  collection.children
+    .map((svgObject: Artboard): void => {
+      let node: XMLElementOrXMLNode;
+
+      switch (svgObject.type) {
+        case 'shape':
+          const shape = svgObject.shape;
+
+          if (shape.type === 'compound' && !options.preferCompoundPath) {
+            node = parent.element('g');
+            createElem(shape, node, defs, options);
+
+            break;
+          }
+
+          node = createShape(shape, parent);
+          applyBorderRadius(svgObject, shape, defs);
+          break;
+
+        case 'text':
+          node = TextConverter.createText(svgObject.text, parent).result;
+          break;
+
+        case 'group':
+          node = parent.element('g');
+          createElem(svgObject.group, node, defs, options);
+          break;
+
+        default:
+          console.warn(`${logger.bold(logger.red('Create element:'))} unknown type: %j`, svgObject);
+          return;
+      }
+
+      applyAttributes(node, defs, svgObject);
+    });
+
+  return parent;
+}
+
+function applyBorderRadius(svgObject: Artboard, shape: Shape, defs: XMLElementOrXMLNode) {
+  if (shape.type === 'rect' && shape.r) {
+    const {width, height, r} = shape;
+    const ref = `clip-path-${width}-${height}-${r.join('-')}`;
+
+    createClipPath({width, height, r}, ref, defs);
+
+    svgObject.style = svgObject.style || {};
+    svgObject.style.clipPath = {ref};
+  }
+}
+
+function createClipPath(data: SvgRectToClipPath, id: string, defs: XMLElementOrXMLNode) {
+  const {width, height, r} = data;
+  const maxBR = Math.min(width, height) / 2;
+
+  const clipPath = svgRectToClipPath({
+    height,
+    r: [
+      Math.min(r[0], maxBR),
+      Math.min(r[1], maxBR),
+      Math.min(r[2], maxBR),
+      Math.min(r[3], maxBR),
+    ],
+    width,
+  }, defs);
+
+  clipPath.attribute('id', id);
+}
+
+function applyAttributes(node: XMLElementOrXMLNode, defs: XMLElementOrXMLNode, svgObject: Artboard) {
+  applyIfPossible(node, 'id', svgObject.id);
+  applyIfPossible(node, 'name', svgObject.name);
+
+  if (svgObject.visible === false) {
+    svgObject.style ? svgObject.style.display = 'none' : svgObject.style = {display: 'none'};
+  }
+
+  if (svgObject.style) {
+    node.attribute('style', createStyles(svgObject.style, defs));
+  }
+
+  if (svgObject.transform) {
+    node.attribute('transform', createTransforms(svgObject.transform));
+  }
+}
+
+function createTransforms(src): string {
+  return `matrix(${src.a}, ${src.b}, ${src.c}, ${src.d}, ${src.tx}, ${src.ty})`;
+}

--- a/src/xd2svg.ts
+++ b/src/xd2svg.ts
@@ -6,27 +6,19 @@
  * found in the LICENSE file at https://github.com/L2jLiga/xd2svg/LICENSE
  */
 
-import * as extractZip                                                  from 'extract-zip';
-import { existsSync, lstatSync, writeFileSync }                         from 'fs';
-import { dirSync, SynchrounousResult }                                  from 'tmp';
-import { promisify }                                                    from 'util';
-import { defaultOptions, Dictionary, Directory, Options, OutputFormat } from './common';
-import { proceedFile }                                                  from './core';
-import * as logger                                                      from './utils/logger';
+import * as extractZip                                                                                from 'extract-zip';
+import { existsSync, lstatSync, writeFileSync }                                                       from 'fs';
+import { dirSync, SynchrounousResult }                                                                from 'tmp';
+import { promisify }                                                                                  from 'util';
+import { defaultOptions, Dictionary, Directory, MultipleOutput, Options, OutputFormat, SingleOutput } from './common';
+import { proceedFile }                                                                                from './core';
+import * as logger                                                                                    from './utils/logger';
 
 const extract = promisify(extractZip);
 
-interface SingleOutput extends Options {
-  single: true;
-}
-
-interface MultipleOutput extends Options {
-  single: false;
-}
-
-export default async function xd2svg(input: string | Buffer, options: SingleOutput): Promise<string>;
+export default async function xd2svg(input: string | Buffer, options?: SingleOutput): Promise<string>;
 export default async function xd2svg(input: string | Buffer, options?: MultipleOutput): Promise<Dictionary<string>>;
-export default async function xd2svg(input: string | Buffer, options: Options): Promise<OutputFormat>;
+export default async function xd2svg(input: string | Buffer, options?: Options): Promise<OutputFormat>;
 export default async function xd2svg(input: string | Buffer, options: Options = defaultOptions): Promise<OutputFormat> {
   const opts: Options = {
     ...defaultOptions,
@@ -34,7 +26,7 @@ export default async function xd2svg(input: string | Buffer, options: Options = 
   };
 
   const directory: Directory = await openMockup(input);
-  const svg: string | Dictionary<string> = proceedFile(directory, opts.single, opts.prettyPrint);
+  const svg: string | Dictionary<string> = proceedFile(directory, opts);
 
   if (directory.removeCallback) directory.removeCallback();
 

--- a/test/core/artboard-converter.spec.ts
+++ b/test/core/artboard-converter.spec.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://github.com/L2jLiga/xd2svg/LICENSE
  */
 
-import * as assert                       from 'assert';
-import * as builder                      from 'xmlbuilder';
-import { artboardConverter, createElem } from '../../src/core/artboard-converter';
-import { Artboard, ArtboardInfo }        from '../../src/core/models';
+import * as assert                from 'assert';
+import { artboardConverter }      from '../../src/core/artboard-converter';
+import { Artboard, ArtboardInfo } from '../../src/core/models';
 
 describe('Core > Artboard converter', () => {
   it('should create svg from empty artboard', () => {
@@ -27,7 +26,7 @@ describe('Core > Artboard converter', () => {
       y: 0,
     } as any;
 
-    const actual = artboardConverter(artboard, artboardInfo);
+    const actual = artboardConverter(artboard, artboardInfo, {});
     const expected = [
       '<svg enable-background="new 0 0 undefined undefined" id="undefined" viewBox="0 0 undefined undefined">' +
       '<title>some</title>' +
@@ -37,91 +36,5 @@ describe('Core > Artboard converter', () => {
     ];
 
     assert.deepEqual(actual, expected);
-  });
-
-  describe('Create element', () => {
-    it('should warn when unknown type', (done) => {
-      const warn = console.warn;
-
-      console.warn = () => {
-        done();
-
-        console.warn = warn;
-      };
-
-      createElem({
-        children: [{type: 'unknownType'}],
-      } as any, null, null);
-    });
-
-    it('should create text element', () => {
-      const parent = builder.begin();
-
-      const svgObjCollection: any = {
-        children: [
-          {
-            style: {},
-            text: {
-              paragraphs: [
-                {
-                  lines: [
-                    [{from: 0, to: 3}],
-                  ],
-                },
-              ],
-              rawText: 'raw',
-            },
-            type: 'text',
-            visible: false,
-          },
-        ],
-      };
-
-      createElem(svgObjCollection, parent, null);
-
-      assert.equal(parent.end(), '<text style="display: none"><tspan>raw</tspan></text>');
-    });
-
-    it('should warn when unsupported shape', (done) => {
-      const warn = console.warn;
-
-      console.warn = () => {
-        done();
-
-        console.warn = warn;
-      };
-
-      createElem({
-        children: [{type: 'shape', shape: {type: 'unknownShape'}}],
-      } as any, builder.begin(), null);
-    });
-
-    it('should create clipPath element when rectangle element has border radius property', () => {
-      const parent = builder.begin();
-      const defs = builder.begin();
-
-      const svgObjCollection: any = {
-        children: [{
-          shape: {
-            height: 15,
-            r: [5, 6, 5, 6],
-            type: 'rect',
-            width: 15,
-            x: 1,
-            y: 2,
-          },
-          type: 'shape',
-        }],
-      };
-
-      createElem(svgObjCollection, parent, defs);
-
-      const clipPath = '<clipPath id="clip-path-15-15-5-6-5-6">' +
-        '<path d="M5 0h4a 6 5 0 0 1 6 5v4a 6 5 0 0 1 -6 5h-4a 5 6 0 0 1 -5 -6v-4a 6 5 0 0 1 6 -5z"/>' +
-        '</clipPath>';
-
-      assert.equal(defs.end(), clipPath);
-      assert.equal(parent.end(), '<rect x="1" y="2" width="15" height="15" style="clip-path: url(#clip-path-15-15-5-6-5-6)"/>');
-    });
   });
 });

--- a/test/core/utils/create-elem.spec.ts
+++ b/test/core/utils/create-elem.spec.ts
@@ -1,0 +1,89 @@
+import * as assert    from 'assert';
+import * as builder   from 'xmlbuilder';
+import { createElem } from '../../../src/core/utils/create-elem';
+
+describe('Create element', () => {
+  it('should warn when unknown type', (done) => {
+    const warn = console.warn;
+
+    console.warn = () => {
+      done();
+
+      console.warn = warn;
+    };
+
+    createElem({
+      children: [{type: 'unknownType'}],
+    } as any, null, null);
+  });
+
+  it('should create text element', () => {
+    const parent = builder.begin();
+
+    const svgObjCollection: any = {
+      children: [
+        {
+          style: {},
+          text: {
+            paragraphs: [
+              {
+                lines: [
+                  [{from: 0, to: 3}],
+                ],
+              },
+            ],
+            rawText: 'raw',
+          },
+          type: 'text',
+          visible: false,
+        },
+      ],
+    };
+
+    createElem(svgObjCollection, parent, null);
+
+    assert.equal(parent.end(), '<text style="display: none"><tspan>raw</tspan></text>');
+  });
+
+  it('should warn when unsupported shape', (done) => {
+    const warn = console.warn;
+
+    console.warn = () => {
+      done();
+
+      console.warn = warn;
+    };
+
+    createElem({
+      children: [{type: 'shape', shape: {type: 'unknownShape'}}],
+    } as any, builder.begin(), null);
+  });
+
+  it('should create clipPath element when rectangle element has border radius property', () => {
+    const parent = builder.begin();
+    const defs = builder.begin();
+
+    const svgObjCollection: any = {
+      children: [{
+        shape: {
+          height: 15,
+          r: [5, 6, 5, 6],
+          type: 'rect',
+          width: 15,
+          x: 1,
+          y: 2,
+        },
+        type: 'shape',
+      }],
+    };
+
+    createElem(svgObjCollection, parent, defs);
+
+    const clipPath = '<clipPath id="clip-path-15-15-5-6-5-6">' +
+      '<path d="M5 0h4a 6 5 0 0 1 6 5v4a 6 5 0 0 1 -6 5h-4a 5 6 0 0 1 -5 -6v-4a 6 5 0 0 1 6 -5z"/>' +
+      '</clipPath>';
+
+    assert.equal(defs.end(), clipPath);
+    assert.equal(parent.end(), '<rect x="1" y="2" width="15" height="15" style="clip-path: url(#clip-path-15-15-5-6-5-6)"/>');
+  });
+});

--- a/test/xd2svg.spec.ts
+++ b/test/xd2svg.spec.ts
@@ -52,25 +52,21 @@ describe('Complex test for xd2svg', () => {
       .catch(() => done());
   });
 
-  it('should correctly convert when buffer provided', (done) => {
+  it('should correctly convert when buffer provided', () => {
     const inputBuffer: Buffer = Buffer.from(readFileSync('test/single.xd'));
 
-    xd2svg(inputBuffer, {single: true})
+    return xd2svg(inputBuffer, {single: true})
       .then((svgImage: string) => convert(svgImage, {puppeteer: {args: ['--no-sandbox']}}) as Promise<Buffer>)
-      .then((actual) => runDiffFor(actual, 'test/expected/single.png'))
-      .then(done)
-      .catch(done);
+      .then((actual) => runDiffFor(actual, 'test/expected/single.png'));
   });
 
-  it('should correctly convert when provided path to file', (done) => {
-    xd2svg('test/single.xd', {single: true})
+  it('should correctly convert when provided path to file', () => {
+    return xd2svg('test/single.xd', {single: true})
       .then((svgImage: string) => convert(svgImage, {puppeteer: {args: ['--no-sandbox']}}) as Promise<Buffer>)
-      .then((actual) => runDiffFor(actual, 'test/expected/single.png'))
-      .then(done)
-      .catch(done);
+      .then((actual) => runDiffFor(actual, 'test/expected/single.png'));
   });
 
-  it('should correctly convert when provided directory with extracted mockup', (done) => {
+  it('should correctly convert when provided directory with extracted mockup', () => {
     const tmpDir = dirSync({
       postfix: 'test-directory',
       unsafeCleanup: true,
@@ -78,8 +74,8 @@ describe('Complex test for xd2svg', () => {
 
     let keys: string[];
 
-    promisify(extractZip)('test/multi.xd', {dir: tmpDir.name})
-      .then(() => xd2svg(tmpDir.name, {prettyPrint: true}))
+    return promisify(extractZip)('test/multi.xd', {dir: tmpDir.name})
+      .then(() => xd2svg(tmpDir.name, {prettyPrint: true, preferCompoundPath: false}))
       .then((SVGs) => {
         keys = Object.keys(SVGs);
         return Promise.all(Object.values(SVGs).map((SVG) => convert(SVG, {
@@ -93,9 +89,7 @@ describe('Complex test for xd2svg', () => {
         const diffs = keys.map((key: string, index: number) => runDiffFor(images[index], `test/expected/${key}.png`));
 
         return Promise.all(diffs);
-      })
-      .then(() => done())
-      .catch(done);
+      });
   });
 });
 

--- a/tslint.json
+++ b/tslint.json
@@ -12,7 +12,7 @@
   "rules": {
     "max-line-length": {
       "options": [
-        160
+        200
       ]
     },
     "quotemark": {


### PR DESCRIPTION
`xd2svg file.xd --prefer-compound-path=false` will produce files when all possible compound paths were replaced with their source